### PR TITLE
Change: rename BlossomLeaf to BlossomIO

### DIFF
--- a/src/bind_thread_to_core.cpp
+++ b/src/bind_thread_to_core.cpp
@@ -60,13 +60,13 @@ BindThreadToCore::BindThreadToCore()
  * @brief runTask
  */
 bool
-BindThreadToCore::runTask(Sakura::BlossomLeaf &blossomLeaf,
+BindThreadToCore::runTask(Sakura::BlossomIO &blossomIO,
                           const DataMap &,
                           Sakura::BlossomStatus &status,
                           ErrorContainer &error)
 {
-    const std::string threadName = blossomLeaf.input.get("thread_name").getString();
-    const DataArray* coreIdsArray = blossomLeaf.input.get("core_ids").getItemContent()->toArray();
+    const std::string threadName = blossomIO.input.get("thread_name").getString();
+    const DataArray* coreIdsArray = blossomIO.input.get("core_ids").getItemContent()->toArray();
 
     // convert core-ids
     std::vector<uint64_t> coreIds;

--- a/src/bind_thread_to_core.h
+++ b/src/bind_thread_to_core.h
@@ -35,7 +35,7 @@ public:
     BindThreadToCore();
 
 protected:
-    bool runTask(Kitsunemimi::Sakura::BlossomLeaf &blossomLeaf,
+    bool runTask(Kitsunemimi::Sakura::BlossomIO &blossomIO,
                  const Kitsunemimi::DataMap &,
                  Kitsunemimi::Sakura::BlossomStatus &status,
                  Kitsunemimi::ErrorContainer &error);

--- a/src/get_thread_mapping.cpp
+++ b/src/get_thread_mapping.cpp
@@ -50,7 +50,7 @@ GetThreadMapping::GetThreadMapping()
  * @brief runTask
  */
 bool
-GetThreadMapping::runTask(Sakura::BlossomLeaf &blossomLeaf,
+GetThreadMapping::runTask(Sakura::BlossomIO &blossomIO,
                           const DataMap &,
                           Sakura::BlossomStatus &,
                           ErrorContainer &)
@@ -77,7 +77,7 @@ GetThreadMapping::runTask(Sakura::BlossomLeaf &blossomLeaf,
         result->insert(name, threadArray);
     }
 
-    blossomLeaf.output.insert("thread_map", result);
+    blossomIO.output.insert("thread_map", result);
 
     return true;
 }

--- a/src/get_thread_mapping.h
+++ b/src/get_thread_mapping.h
@@ -35,7 +35,7 @@ public:
     GetThreadMapping();
 
 protected:
-    bool runTask(Kitsunemimi::Sakura::BlossomLeaf &blossomLeaf,
+    bool runTask(Kitsunemimi::Sakura::BlossomIO &blossomIO,
                  const Kitsunemimi::DataMap &,
                  Kitsunemimi::Sakura::BlossomStatus &,
                  Kitsunemimi::ErrorContainer &);


### PR DESCRIPTION
## Description

Change: rename BlossomLeaf to BlossomIO

## Related Issues

- https://github.com/kitsudaiki/HanamiAI/issues/13

## How it was tested

- ci-pipeline